### PR TITLE
Fix errors caused by leading <br/> removal patch

### DIFF
--- a/src/math-editor/editor.js
+++ b/src/math-editor/editor.js
@@ -321,7 +321,7 @@ class Editor {
                 // We can expect a new line is created here
                 requestAnimationFrame(() => {
                     const newline = Utils.listToArray(this.hook.childNodes)[Utils.getNodeIndex(this.hook, this.activeLine)]
-                    if (newline.childNodes[0].nodeName.toLowerCase() === "br" && newline.childNodes.length > 1) newline.childNodes[0].remove()
+                    if (newline.childNodes.length > 1 && newline.childNodes[0].nodeName.toLowerCase() === "br") newline.childNodes[0].remove()
                 })
             }
 


### PR DESCRIPTION
Fixes an error where our heading <br/> removal patch tried to remove non-existent elements, leading to possibly indexing into an empty array. Problematic line was https://github.com/Testausserveri/matikkaeditori.fi-v3/blob/aa97cb40f57cba2698739dfbc8d93ac0987bd6bf/src/math-editor/editor.js#L324